### PR TITLE
Add 0.5s to duration instead of 1s

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -23,7 +23,7 @@ func (i CPU_Usage) EqualTo(j CPU_Usage) bool {
 // CPU_Usage holds information needed to calculate CPU credits usage
 type CPU_Usage struct {
 	PCPU     float64 // cpu utilization of the process in %
-	Duration int     // cumulative CPU time in seconds
+	Duration float64 // cumulative CPU time in seconds
 	Program  string  // name of the (parent) program
 	PID      int     // pid of the process
 	User     string  // effective user name
@@ -82,7 +82,7 @@ func parseStatPS(psOut string) (usages []CPU_Usage) {
 		infoArr := strings.Fields(line)
 		usages = append(usages, CPU_Usage{
 			PCPU:     parseFloat(infoArr[0]),
-			Duration: parseCPUTime(infoArr[1]) + 1, // because we are checking every second
+			Duration: parseCPUTime(infoArr[1]) + 0.5, // because we are checking every second
 			Program:  infoArr[4],
 			PID:      parseInt(infoArr[2]),
 			User:     infoArr[3],
@@ -164,24 +164,24 @@ func parseFloat(val string) float64 {
 }
 
 // parseCPUTime parses cumulative CPU time, "[DD-]hh:mm:ss" format to int (seconds only).
-func parseCPUTime(val string) (duration int) {
+func parseCPUTime(val string) (duration float64) {
 	if strings.Contains(val, "-") {
 		splitDays := strings.Split(val, "-")
 		days := splitDays[0]
 
 		if days != "" {
 			secInDay := 24 * 60 * 60
-			duration += secInDay * parseInt(days) // add days
+			duration += float64(secInDay * parseInt(days)) // add days
 		}
 		val = splitDays[1]
 	}
 
 	splitTime := strings.Split(val, ":")
-	hours := parseInt(splitTime[0])
+	hours := parseFloat(splitTime[0])
 	duration += hours * 60 * 60 // add hours
-	min := parseInt(splitTime[1])
-	duration += min * 60               // add minutes
-	duration += parseInt(splitTime[2]) // add seconds
+	min := parseFloat(splitTime[1])
+	duration += min * 60                 // add minutes
+	duration += parseFloat(splitTime[2]) // add seconds
 
 	return
 }

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -87,10 +87,10 @@ func Test_parseStatPS(t *testing.T) {
 `
 	got := parseStatPS(psOut)
 	want := []CPU_Usage{
-		{0.1, 6, "myprogram", 3477510, "root"},
-		{0.4, 62, "myprogram", 3518860, "worker1"},
-		{28.0, 3673, "myprogram", 3520027, "worker2"},
-		{6.1, 4, "myprogram", 3519918, "worker3"},
+		{0.1, 5.5, "myprogram", 3477510, "root"},
+		{0.4, 61.5, "myprogram", 3518860, "worker1"},
+		{28.0, 3672.5, "myprogram", 3520027, "worker2"},
+		{6.1, 3.5, "myprogram", 3519918, "worker3"},
 	}
 	assert.Equal(t, want, got)
 }
@@ -102,7 +102,7 @@ func Test_parseCPUTime(t *testing.T) {
 	tests := []struct {
 		name         string
 		args         args
-		wantDuration int
+		wantDuration float64
 	}{
 		{"just seconds", args{"00:00:01"}, 1},
 		{"just minutes", args{"00:01:00"}, 60},

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ let
   }) { };
 in buildGoModule.override { go = pkgs.go_1_18; }  rec {
   pname = "psusage";
-  version = "1.0.4";
+  version = "1.0.5";
 
   src = nix-gitignore.gitignoreSource [ ] ./.;
 


### PR DESCRIPTION
Because we check `ps` stats every second, we'll have cumulative CPU
time off by 0.5s on average and not by 1s.

Ideally, we would check `ps` stats even more often so we can be more
accurate for short-lived processes (e.g. php-fpm child workers) but
that might be too resource intensive.